### PR TITLE
add Count events

### DIFF
--- a/webserver.py
+++ b/webserver.py
@@ -82,7 +82,9 @@ def next_event():
     count = int(request.args.get('c', 1))  # Standardwert: 1
     next_events = get_next_events(count)
 
-    if next_events:
+    if len(next_events) == 1 :
+        return jsonify(next_events[0])
+    elif len(next_events) > 1:
         return jsonify(next_events)
     else:
         return jsonify({'error': 'Failed to fetch calendar events'})


### PR DESCRIPTION
adding the count functionality to endpoint /api/ne
this will allow us to not only get the `next` event, also get the `next events` based on today an `n` events in the future.

`/api/ne?c=4` will return a list of 4 events
`/api/ne` will return a single object 